### PR TITLE
fix blinking cursor (#336607) ; inverts cursor color

### DIFF
--- a/gui/abstractbytearraycolumnrenderer_p.cpp
+++ b/gui/abstractbytearraycolumnrenderer_p.cpp
@@ -716,6 +716,8 @@ void AbstractByteArrayColumnRendererPrivate::renderCursor(QPainter* painter, Add
         mByteTypeColored ? foregroundRoleForChar(byteChar) : KColorScheme::NormalText;
     const QBrush brush = colorScheme.foreground(foregroundRole);
     painter->fillRect(0, 0, mByteWidth, q->lineHeight(), brush);
+    const QColor& charColor = colorScheme.background(KColorScheme::NormalBackground).color();
+    renderByteText(painter, byte, byteChar, charColor);
 }
 
 bool AbstractByteArrayColumnRendererPrivate::getNextSelectedAddressRange(AddressRange* _selection, unsigned int* _flag,


### PR DESCRIPTION
Ok.. I finally managed to make okteta usable for me again :)
If cursorBlinkRate is set to 0, okteta now draws a nice solid cursor.
The cursor appearance is changed from a solid block to an inverted block (fg for cursor and bg for text), which I think will also be nicer for those who like the blinking.

This is my first official pull request, so please tell me if there is something I should know about.